### PR TITLE
Fix build by self-hosting fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "basecamp-site",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/geist": "^5.2.6",
+        "@fontsource/geist-mono": "^5.2.6",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -220,6 +222,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/geist": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist/-/geist-5.2.6.tgz",
+      "integrity": "sha512-HKRFUn4fApQr9iGaVLUWG5vs+QYFqhKa5X7AFpT6Gey0Kx0ibvpFceMbMDDdlzzqPiGkvCuvYRUN55rvqXgibg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/geist-mono": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-mono/-/geist-mono-5.2.6.tgz",
+      "integrity": "sha512-I3hsRP+8Gmhk35cwlPAR4w5xqk7e5pro2F1o51ZmB+lN+dPcwN3jYHKN+u0E5AMuiQKpTdkrqfEpvBjzQax3cQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,21 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fontsource/geist": "^5.2.6",
+    "@fontsource/geist-mono": "^5.2.6",
+    "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,12 @@
 @import "tailwindcss";
+@import "@fontsource/geist/latin.css";
+@import "@fontsource/geist-mono/latin.css";
 
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --font-geist-sans: "Geist", sans-serif;
+  --font-geist-mono: "Geist Mono", monospace;
 }
 
 @theme inline {
@@ -22,5 +26,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-  display: "swap",
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "Basecamp",
@@ -25,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html lang="en">
       <body className="bg-basecamp-sand text-basecamp-charcoal font-sans antialiased">
         {children}
       </body>


### PR DESCRIPTION
## Summary
- self-host Geist fonts via `@fontsource` packages
- update global styles to use the local fonts
- simplify layout now that fonts are local

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857e4aaa620832db10f6cf766436182