### PR TITLE
Make NextSection join button sand-colored

### DIFF
--- a/src/components/NextSection.tsx
+++ b/src/components/NextSection.tsx
@@ -11,7 +11,7 @@ export default function NextSection() {
         </p>
         <a
           href="/join"
-          className="inline-block bg-basecamp-charcoal text-basecamp-sand font-medium px-6 py-3 rounded-xl shadow hover:bg-black transition"
+          className="inline-block bg-basecamp-sand text-basecamp-charcoal border border-basecamp-charcoal font-medium px-6 py-3 rounded-xl shadow hover:bg-basecamp-cream transition"
         >
           Join the Brotherhood
         </a>


### PR DESCRIPTION
## Summary
- lighten Join button color to keep NextSection clean

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858158d609c832d874ce4e04745dbd2